### PR TITLE
Simple optimizations

### DIFF
--- a/Scripts/ClientCache.cs
+++ b/Scripts/ClientCache.cs
@@ -31,17 +31,13 @@ namespace SpacetimeDB
                 }
 
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                private bool EqualsUnvectorized(byte[] left, byte[] right)
+                private unsafe bool EqualsUnvectorized(byte[] left, byte[] right)
                 {
-                    for (int i = 0; i < left.Length; i++)
-                    {
-                        if (left[i] != right[i])
-                        {
-                            return false;
-                        }
-                    }
-
-                    return true;
+					fixed (byte* a = left)
+					fixed (byte* b = right)
+					{
+						return Unity.Collections.LowLevel.Unsafe.UnsafeUtility.MemCmp(a, b, left.Length) == 0;
+					}
                 }
 
                 public int GetHashCode(byte[] obj)

--- a/Scripts/ClientCache.cs
+++ b/Scripts/ClientCache.cs
@@ -33,11 +33,11 @@ namespace SpacetimeDB
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 private unsafe bool EqualsUnvectorized(byte[] left, byte[] right)
                 {
-					fixed (byte* a = left)
-					fixed (byte* b = right)
-					{
-						return Unity.Collections.LowLevel.Unsafe.UnsafeUtility.MemCmp(a, b, left.Length) == 0;
-					}
+                    fixed (byte* a = left)
+                    fixed (byte* b = right)
+                    {
+                        return Unity.Collections.LowLevel.Unsafe.UnsafeUtility.MemCmp(a, b, left.Length) == 0;
+                    }
                 }
 
                 public int GetHashCode(byte[] obj)

--- a/Scripts/SpacetimeDBClient.cs
+++ b/Scripts/SpacetimeDBClient.cs
@@ -210,8 +210,8 @@ namespace SpacetimeDB
                                          a.GetParameters().Length > 0 &&
                                          a.GetParameters()[0].ParameterType ==
                                          typeof(AlgebraicValue));
-				var decodeDelegate = (Func<AlgebraicValue, object>)conversionFunc.CreateDelegate(typeof(Func<AlgebraicValue, object>));  
-				clientDB.AddTable(@class, algebraicValue, decodeDelegate);
+                var decodeDelegate = (Func<AlgebraicValue, object>)conversionFunc.CreateDelegate(typeof(Func<AlgebraicValue, object>));  
+                clientDB.AddTable(@class, algebraicValue, decodeDelegate);
             }
 
             var reducerType = FindReducerType();
@@ -701,8 +701,8 @@ namespace SpacetimeDB
                                 }
                                 else
                                 {
-									update.op = TableOp.NoChange;
-									dbOps[i] = update;
+                                    update.op = TableOp.NoChange;
+                                    dbOps[i] = update;
                                 }
                                 break;
                             case TableOp.Insert:
@@ -712,8 +712,8 @@ namespace SpacetimeDB
                                 }
                                 else
                                 {
-									update.op = TableOp.NoChange;
-									dbOps[i] = update;
+                                    update.op = TableOp.NoChange;
+                                    dbOps[i] = update;
                                 }
                                 break;
                             case TableOp.Update:
@@ -723,8 +723,8 @@ namespace SpacetimeDB
                                 }
                                 else
                                 {
-									update.op = TableOp.NoChange;
-									dbOps[i] = update;
+                                    update.op = TableOp.NoChange;
+                                    dbOps[i] = update;
                                 }
                                 
                                 if (update.table.InsertEntry(update.insertedPk, update.rowValue))
@@ -733,8 +733,8 @@ namespace SpacetimeDB
                                 }
                                 else
                                 {
-									update.op = TableOp.NoChange;
-									dbOps[i] = update;
+                                    update.op = TableOp.NoChange;
+                                    dbOps[i] = update;
                                 }
                                 break;
                             default:
@@ -746,7 +746,7 @@ namespace SpacetimeDB
                     var updateCount = dbOps.Count;
                     for (var i = 0; i < updateCount; i++)
                     {
-						var dbOp = dbOps[i];
+                        var dbOp = dbOps[i];
                         var tableName = dbOp.table.Name;
                         var tableOp = dbOp.op;
                         var oldValue = dbOp.oldValue;

--- a/Scripts/SpacetimeDBClient.cs
+++ b/Scripts/SpacetimeDBClient.cs
@@ -743,11 +743,9 @@ namespace SpacetimeDB
                     }
 
                     // Send out events
-                    var updateCount = dbOps.Count;
-                    for (var i = 0; i < updateCount; i++)
+                    foreach (var dbOp in dbOps)
                     {
-                        var dbOp = dbOps[i];
-                        var tableName = dbOp.table.Name;
+                        var table = dbOp.table;
                         var tableOp = dbOp.op;
                         var oldValue = dbOp.oldValue;
                         var newValue = dbOp.newValue;
@@ -759,9 +757,9 @@ namespace SpacetimeDB
                                 {
                                     try
                                     {
-                                        if (dbOp.table.InsertCallback != null)
+                                        if (table.InsertCallback != null)
                                         {
-                                            dbOp.table.InsertCallback.Invoke(newValue,
+                                            table.InsertCallback.Invoke(newValue,
                                                 message.TransactionUpdate?.Event);
                                         }
                                     }
@@ -772,9 +770,9 @@ namespace SpacetimeDB
 
                                     try
                                     {
-                                        if (dbOp.table.RowUpdatedCallback != null)
+                                        if (table.RowUpdatedCallback != null)
                                         {
-                                            dbOp.table.RowUpdatedCallback
+                                            table.RowUpdatedCallback
                                                 .Invoke(tableOp, null, newValue, message.TransactionUpdate?.Event);
                                         }
                                     }
@@ -793,11 +791,11 @@ namespace SpacetimeDB
                                 {
                                     if (oldValue != null && newValue == null)
                                     {
-                                        if (dbOp.table.DeleteCallback != null)
+                                        if (table.DeleteCallback != null)
                                         {
                                             try
                                             {
-                                                dbOp.table.DeleteCallback.Invoke(oldValue,
+                                                table.DeleteCallback.Invoke(oldValue,
                                                     message.TransactionUpdate?.Event);
                                             }
                                             catch (Exception e)
@@ -806,11 +804,11 @@ namespace SpacetimeDB
                                             }
                                         }
 
-                                        if (dbOp.table.RowUpdatedCallback != null)
+                                        if (table.RowUpdatedCallback != null)
                                         {
                                             try
                                             {
-                                                dbOp.table.RowUpdatedCallback
+                                                table.RowUpdatedCallback
                                                     .Invoke(tableOp, oldValue, null, message.TransactionUpdate?.Event);
                                             }
                                             catch (Exception e)
@@ -832,9 +830,9 @@ namespace SpacetimeDB
                                     {
                                         try
                                         {
-                                            if (dbOp.table.UpdateCallback != null)
+                                            if (table.UpdateCallback != null)
                                             {
-                                                dbOp.table.UpdateCallback.Invoke(oldValue, newValue,
+                                                table.UpdateCallback.Invoke(oldValue, newValue,
                                                     message.TransactionUpdate?.Event);
                                             }
                                         }
@@ -845,9 +843,9 @@ namespace SpacetimeDB
 
                                         try
                                         {
-                                            if (dbOp.table.RowUpdatedCallback != null)
+                                            if (table.RowUpdatedCallback != null)
                                             {
-                                                dbOp.table.RowUpdatedCallback
+                                                table.RowUpdatedCallback
                                                     .Invoke(tableOp, oldValue, newValue, message.TransactionUpdate?.Event);
                                             }
                                         }
@@ -872,7 +870,7 @@ namespace SpacetimeDB
 
                         if (tableOp != TableOp.NoChange)
                         {
-                            onRowUpdate?.Invoke(tableName, tableOp, oldValue, newValue,
+                            onRowUpdate?.Invoke(table.Name, tableOp, oldValue, newValue,
                                 message.Event?.FunctionCall.CallInfo);
                         }
                     }

--- a/Scripts/com.clockworklabs.spacetimedbsdk.asmdef
+++ b/Scripts/com.clockworklabs.spacetimedbsdk.asmdef
@@ -1,4 +1,4 @@
 {
-	"name": "com.clockworklabs.spacetimedbsdk",
+    "name": "com.clockworklabs.spacetimedbsdk",
     "allowUnsafeCode": true
 }

--- a/Scripts/com.clockworklabs.spacetimedbsdk.asmdef
+++ b/Scripts/com.clockworklabs.spacetimedbsdk.asmdef
@@ -1,3 +1,4 @@
 {
-	"name": "NewAssembly"
+	"name": "com.clockworklabs.spacetimedbsdk",
+    "allowUnsafeCode": true
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.clockworklabs.spacetimedbsdk",
   "displayName": "SpacetimeDB SDK",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "The SpacetimeDB Client SDK is a software development kit (SDK) designed to interact with and manipulate SpacetimeDB modules..",
   "keywords": [],
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.clockworklabs.spacetimedbsdk",
   "displayName": "SpacetimeDB SDK",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "The SpacetimeDB Client SDK is a software development kit (SDK) designed to interact with and manipulate SpacetimeDB modules..",
   "keywords": [],
   "dependencies": {


### PR DESCRIPTION
- Optimized `byte[]` comparer
- Deserializing `AlgebraicValue`s now pre-compiles delegates instead of going through reflection every time
- Removed duplicate array reads from `dbOps`
- Table name is no longer retrieved through reflection
- Updated assembly definition name