### PR TITLE
Fixed nullref when exiting game without being connected to SpacetimeDB

### DIFF
--- a/Scripts/WebSocket.cs
+++ b/Scripts/WebSocket.cs
@@ -237,7 +237,10 @@ class OnSendErrorMessage : MainThreadDispatch
 
         public Task Close(WebSocketCloseStatus code = WebSocketCloseStatus.NormalClosure, string reason = null)
         {
-            Ws?.CloseAsync(code, "Disconnecting normally.", CancellationToken.None);
+            if (Ws?.State is WebSocketState.Open or WebSocketState.Connecting)
+            {
+                Ws?.CloseAsync(code, "Disconnecting normally.", CancellationToken.None);
+            }
 
             return Task.CompletedTask;
         }


### PR DESCRIPTION
Currently, if you close a game that uses this SDK without being connected to SpacetimeDB, `NetworkManager` will still try to close `WebSocket` even though it's not open, which will throw `InvalidOperationException: The WebSocket is not connected.`. This PR adds a check that prevents that from happening