### PR TITLE
chore: Replace deprecated newtonsoft pkg w/stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "The SpacetimeDB Client SDK is a software development kit (SDK) designed to interact with and manipulate SpacetimeDB modules..",
   "keywords": [],
   "dependencies": {
-    "com.unity.nuget.newtonsoft-json": "3.0.1"
+    "com.unity.nuget.newtonsoft-json": "3.2.1"
   },
   "author": {
     "name": "Clockwork Labs",


### PR DESCRIPTION
# About

- From "com.unity.nuget.newtonsoft-json": "3.0.1"
- To "com.unity.nuget.newtonsoft-json": "3.2.1"
- Src: https://docs.unity3d.com/Packages/com.unity.nuget.newtonsoft-json@3.2/manual/index.html

## Why?

In all honesty, I originally thought it was using the old, similarly-named repo: But while we're here, we may as well update. Consider this extremely low priority.

## Tests

Pulled it in Unity 2022.3 LTS and had no errs