### PR TITLE
Dylan/feat: Static TimeConvert util

### DIFF
--- a/Scripts/TimeConvert.cs
+++ b/Scripts/TimeConvert.cs
@@ -1,0 +1,57 @@
+ using System;
+
+ namespace SpacetimeDB
+ {
+     /// <summary>
+     /// Handles conversion between long (Rust Timestamps / microseconds since UNIX epoch)
+     /// and DateTimeOffset (UTC)
+     /// </summary>
+     public static class TimeConvert
+     {
+         private static readonly DateTimeOffset unixEpoch = new(
+             year: 1970,
+             month: 1,
+             day: 1,
+             hour: 0,
+             minute: 0,
+             second: 0,
+             offset: TimeSpan.Zero);
+
+         /// <summary>
+         /// Converts from long (Rust Timestamps / microseconds since UNIX epoch) to DateTimeOffset (UTC) 
+         /// </summary>
+         public static DateTimeOffset FromMicrosecondsTimestamp(long microseconds)
+         {
+             long ticks = microseconds * 10;
+             return unixEpoch.AddTicks(ticks);
+         }
+
+         /// <summary>
+         /// Converts from DateTimeOffset (UTC) to long (Rust Timestamps / microsecondssince UNIX epoch)
+         /// </summary>
+         public static long ToMicrosecondsTimestamp(DateTimeOffset dateTimeOffset)
+         {
+             TimeSpan elapsed = dateTimeOffset - unixEpoch;
+             return elapsed.Ticks / 10;
+         }
+
+         /// <summary>
+         /// DateTimeOffset.Now (UTC) to long (Rust Timestamps / microseconds since UNIX epoch)
+         /// </summary>
+         public static long MicrosecondsTimestamp()
+         {
+             TimeSpan elapsed = DateTimeOffset.Now - unixEpoch;
+             return elapsed.Ticks / 10;
+         }
+
+         /// <summary>
+         /// Converts DateTimeOffset (UTC) to a string in ISO 8601 format.
+         /// (!) Less accurate than `ToMicrosecondsTimestamp()`; only use this if required.
+         /// </summary>
+         [Obsolete("This is only useful if your server *requires* ISO 8601, " +
+                   "but it's less accurate than long-based nanoseconds and may be desync'd: " +
+                   "If possible, instead use `ToMicrosecondsTimestamp()`")]
+         public static string ToTimestampIso8601(DateTimeOffset dateTimeOffset) =>
+             dateTimeOffset.ToString("o"); // 'o' format specifier for ISO 8601
+     }
+ }

--- a/Scripts/TimeConvert.cs
+++ b/Scripts/TimeConvert.cs
@@ -8,22 +8,13 @@
      /// </summary>
      public static class TimeConvert
      {
-         private static readonly DateTimeOffset unixEpoch = new(
-             year: 1970,
-             month: 1,
-             day: 1,
-             hour: 0,
-             minute: 0,
-             second: 0,
-             offset: TimeSpan.Zero);
-
          /// <summary>
          /// Converts from long (Rust Timestamps / microseconds since UNIX epoch) to DateTimeOffset (UTC) 
          /// </summary>
          public static DateTimeOffset FromMicrosecondsTimestamp(long microseconds)
          {
              long ticks = microseconds * 10;
-             return unixEpoch.AddTicks(ticks);
+             return DateTime.UnixEpoch.AddTicks(ticks);
          }
 
          /// <summary>
@@ -31,7 +22,7 @@
          /// </summary>
          public static long ToMicrosecondsTimestamp(DateTimeOffset dateTimeOffset)
          {
-             TimeSpan elapsed = dateTimeOffset - unixEpoch;
+             TimeSpan elapsed = dateTimeOffset - DateTime.UnixEpoch;
              return elapsed.Ticks / 10;
          }
 
@@ -40,7 +31,7 @@
          /// </summary>
          public static long MicrosecondsTimestamp()
          {
-             TimeSpan elapsed = DateTimeOffset.Now - unixEpoch;
+             TimeSpan elapsed = DateTimeOffset.Now - DateTime.UnixEpoch;
              return elapsed.Ticks / 10;
          }
 

--- a/Scripts/TimeConvert.cs.meta
+++ b/Scripts/TimeConvert.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dae1da296714ead49b01792cabc601cb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# About

Add a static `TimeConvert` helper class to the Unity SDK

## Why?

In Rust, `.timestamp()` is pretty straight-forward. However, for C#? There are a million ways to do it, and almost all of the ones most people would initially think are probably wrong (including my own theories when I was eating my own dogfood converting scripts from rs to c#). 

I was originally using an ISO timestamp since it's accepted by most DBs, for example - that was not in microseconds. However, it can also get messy quite fast and can inaccurate as things get parsed back-and-forth. 

To simplify things, this helper class can help keep things consistent and makes it as close as the Rust timestamp() call as possible, converting both ways.

**EDIT:** After Ingvar pointing out there's an official [DateTime.UnixEpoch](https://learn.microsoft.com/en-us/dotnet/api/system.datetime.unixepoch?view=netstandard-2.1), this makes this PR way less needed. However, it may still be useful to provide *official* convert consistency (with inline docs) since DateTime-like converts always raise questions/concerns.

## Feats

- `public static DateTimeOffset FromMicrosecondsTimestamp(long microseconds)`
- `public static long ToMicrosecondsTimestamp(DateTimeOffset dateTimeOffset)`
- `public static long MicrosecondsTimestamp()`
- `[Obsolete] public static string ToTimestampIso8601(DateTimeOffset dateTimeOffset)`
   - Kept in case you need to transfer the data somewhere else, where often an ISO 8601 timestamp string is required. There's a hefty note warning that this is not as accurate, recommending another func.

## Additional Note

I recently updated [Zeke's Demo mini upgrade PR](https://github.com/clockworklabs/zeke-demo-project/pull/1) to have a duplicate TimeConvert class to ensure synchronicity (which will dupe into the [new demo docs](https://github.com/clockworklabs/spacetime-docs/pull/37) later).