### PR TITLE
Add CI checks for merging into `master`

### DIFF
--- a/.github/workflows/check-pr-base.yml
+++ b/.github/workflows/check-pr-base.yml
@@ -1,0 +1,22 @@
+name: Git tree checks
+
+on:
+  pull_request:
+    types: [opened, edited]
+  merge_group:
+permissions: read-all
+
+jobs:
+  check_base_ref:
+    name: Based on `master`
+    runs-on: ubuntu-latest
+    steps:
+      - id: not_based_on_master
+        if: |
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.base.ref == 'master' &&
+          github.event.pull_request.head.ref != 'staging'
+        run: |
+          echo 'Only the `staging` branch is allowed to merge into `master`.'
+          echo 'Maybe your PR should be merging into `staging`?'
+          exit 1

--- a/.github/workflows/check-pr-base.yml
+++ b/.github/workflows/check-pr-base.yml
@@ -8,7 +8,7 @@ permissions: read-all
 
 jobs:
   check_base_ref:
-    name: Based on `master`
+    name: Only `staging` may merge into `master`
     runs-on: ubuntu-latest
     steps:
       - id: not_based_on_master


### PR DESCRIPTION
## Description
Add a CI check that fails if a PR is merging directly into `master` rather than into `staging` (unless the PR is from the `staging` branch itself)

## Testing
- [x] See the check failing on this PR (not yet a required check)
- [x] Example PR into `staging` from another branch: https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk/pull/48