### PR TITLE
CI - Only allow `release/*` branches to merge into `master`

### DIFF
--- a/.github/workflows/check-pr-base.yml
+++ b/.github/workflows/check-pr-base.yml
@@ -8,15 +8,15 @@ permissions: read-all
 
 jobs:
   check_base_ref:
-    name: Only `staging` may merge into `master`
+    name: Only release branches may merge into master
     runs-on: ubuntu-latest
     steps:
       - id: not_based_on_master
         if: |
           github.event_name == 'pull_request' &&
           github.event.pull_request.base.ref == 'master' &&
-          github.event.pull_request.head.ref != 'staging'
+          startsWith(github.event.pull_request.head.ref, 'release/')
         run: |
-          echo 'Only the `staging` branch is allowed to merge into `master`.'
+          echo 'Only `release/*` branches are allowed to merge into `master`.'
           echo 'Maybe your PR should be merging into `staging`?'
           exit 1


### PR DESCRIPTION
I think instead of letting `staging` merge into `master`, we should allow `release/foo` branches to merge into `master`.

If it's just `staging` then we can't actually cut & deploy a specific release branch that's "frozen" at a particular commit.