### PR TITLE
Fix #56: CI - Only allow `release/*` branches to merge into `master`

### DIFF
--- a/.github/workflows/check-pr-base.yml
+++ b/.github/workflows/check-pr-base.yml
@@ -15,7 +15,7 @@ jobs:
         if: |
           github.event_name == 'pull_request' &&
           github.event.pull_request.base.ref == 'master' &&
-          startsWith(github.event.pull_request.head.ref, 'release/')
+          ! startsWith(github.event.pull_request.head.ref, 'release/')
         run: |
           echo 'Only `release/*` branches are allowed to merge into `master`.'
           echo 'Maybe your PR should be merging into `staging`?'


### PR DESCRIPTION
The previous logic was missing a `!`, so that only branches that did _not_ start with `release/` were allowed to merge into master :sweat: 