### PR TITLE
Fix #56: CI - Only allow `release/*` branches to merge into `master`

### DIFF
--- a/.github/workflows/check-pr-base.yml
+++ b/.github/workflows/check-pr-base.yml
@@ -2,7 +2,7 @@ name: Git tree checks
 
 on:
   pull_request:
-    types: [opened, edited]
+    types: [opened, edited, reopened, synchronize]
   merge_group:
 permissions: read-all
 


### PR DESCRIPTION
This check only ran on certain PR events. It did not run on commit pushes. Since it was a required check, it apparently must run on every commit to avoid being stuck in the "expected" state forever...

I am absolutely perplexed that this is the case, and I swear this is not how these semantics have always worked. Nonetheless, it seems to be how they work, so I humbly open a PR to prevent these from being stuck forever.

Why GitHub allows this is beyond me. If status checks are no longer applied to a PR when a new commit is pushed, it seems very weird to allow them to not be run on every push.